### PR TITLE
Store uploads on Render Disk

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,5 +1,19 @@
 const multer = require("multer");
-const storage = multer.memoryStorage();
+const fs = require("fs");
+const path = require("path");
+
+// Directory where uploaded files will be stored. On Render this should
+// be a persistent disk mount (e.g. `/var/data`).
+const uploadDir = process.env.UPLOAD_DIR || "/var/data/uploads";
+fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const unique = Date.now() + "-" + Math.random().toString(36).slice(2);
+    cb(null, unique + path.extname(file.originalname));
+  },
+});
 
 const upload = multer({
   storage,


### PR DESCRIPTION
## Summary
- use disk storage in multer
- store uploaded file paths in the database
- stream files from Render Disk when serving content
- remove files from disk on update/delete
- keep PDFs stored directly in PostgreSQL

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/render-sparkhub/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_684589d277a88327866ea1a5aff39058